### PR TITLE
Orientation

### DIFF
--- a/SplineCam/src/SplineCam/Spline/Spline.h
+++ b/SplineCam/src/SplineCam/Spline/Spline.h
@@ -59,6 +59,15 @@ public:
 		glVertex3f(controlPoints[selectedControlPoint].x, controlPoints[selectedControlPoint].y, controlPoints[selectedControlPoint].z);
 		glEnd();
 
+		// draw selected control point custom orientation
+		shader.SetUniform("color", glm::vec4(1.0f, 1.0f, 0.0f, 1.0f));
+		glBegin(GL_LINES);
+		glVertex3f(controlPoints[selectedControlPoint].x, controlPoints[selectedControlPoint].y, controlPoints[selectedControlPoint].z);
+		glVertex3f(controlPoints[selectedControlPoint].x + orientations[selectedControlPoint].x, 
+			controlPoints[selectedControlPoint].y + orientations[selectedControlPoint].y, 
+			controlPoints[selectedControlPoint].z + orientations[selectedControlPoint].z);
+		glEnd();
+
 		// draw the control points
 		shader.SetUniform("color", glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
 		glPointSize(10.0f);
@@ -66,6 +75,17 @@ public:
 		for (unsigned int i = 0; i < controlPoints.size(); i++) {
 			if (i != selectedControlPoint)
 				glVertex3f(controlPoints[i].x, controlPoints[i].y, controlPoints[i].z);
+		}
+		glEnd();
+
+		// draw custom orientations
+		shader.SetUniform("color", glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+		glBegin(GL_LINES);
+		for (unsigned int i = 0; i < orientations.size(); i++) {
+			if (i != selectedControlPoint) {
+				glVertex3f(controlPoints[i].x, controlPoints[i].y, controlPoints[i].z);
+				glVertex3f(controlPoints[i].x + orientations[i].x, controlPoints[i].y + orientations[i].y, controlPoints[i].z + orientations[i].z);
+			}
 		}
 		glEnd();
 

--- a/SplineCam/src/SplineCam/Spline/Spline.h
+++ b/SplineCam/src/SplineCam/Spline/Spline.h
@@ -128,6 +128,15 @@ public:
 	void NextControlPoint() { selectedControlPoint = (selectedControlPoint + 1) % controlPoints.size(); }
 	void PreviousControlPoint() { selectedControlPoint = selectedControlPoint == 0 ? controlPoints.size() - 1 : selectedControlPoint - 1; }
 	void TranslateControlPoint(glm::vec3 translate) { controlPoints[selectedControlPoint] += translate; CalculateSplinePoints(); }
+	void RotateControlPoint(float dx, float dy) {
+		if (orientations[selectedControlPoint] == glm::vec3())
+			orientations[selectedControlPoint] = glm::vec3(1.0f, 0.0f, 0.0f);
+
+		glm::mat4 mat(1);
+		mat = glm::rotate(mat, dy, glm::vec3(0.0f, 1.0f, 0.0f));
+		mat = glm::rotate(mat, dx, glm::cross(orientations[selectedControlPoint], glm::vec3(0.0f, 1.0f, 0.0f)));
+		orientations[selectedControlPoint] = glm::normalize(glm::vec3(mat * glm::vec4(orientations[selectedControlPoint], 1.0f)));
+	}
 
 	void CreateControlPoint() { 
 		controlPoints.insert(controlPoints.begin() + selectedControlPoint + 1, controlPoints[selectedControlPoint]);
@@ -146,6 +155,8 @@ public:
 			CalculateSplinePoints();
 		}
 	}
+
+	void DeleteCustomOrientation() { orientations[selectedControlPoint] = glm::vec3(); }
 
 	void ToggleDebugPoints() { drawDebugPoints = !drawDebugPoints; }
 

--- a/SplineCam/src/SplineCam/Spline/Spline.h
+++ b/SplineCam/src/SplineCam/Spline/Spline.h
@@ -130,8 +130,8 @@ public:
 	void TranslateControlPoint(glm::vec3 translate) { controlPoints[selectedControlPoint] += translate; CalculateSplinePoints(); }
 
 	void CreateControlPoint() { 
-		controlPoints.insert(controlPoints.begin() + selectedControlPoint, controlPoints[selectedControlPoint]);
-		orientations.insert(orientations.begin() + selectedControlPoint, glm::vec3());
+		controlPoints.insert(controlPoints.begin() + selectedControlPoint + 1, controlPoints[selectedControlPoint]);
+		orientations.insert(orientations.begin() + selectedControlPoint + 1, glm::vec3());
 		if (selectedControlPoint != controlPoints.size())
 			NextControlPoint();
 		CalculateSplinePoints();

--- a/SplineCam/src/SplineCam/Spline/Spline.h
+++ b/SplineCam/src/SplineCam/Spline/Spline.h
@@ -2,6 +2,8 @@
 #define SPLINE_H
 
 #include <vector>
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 class Spline
 {
@@ -142,13 +144,13 @@ protected:
 		int n = controlPoints.size() - 1;
 		glm::vec3 tangent = GetTangent(t, i);
 		glm::vec3 a = tangent, b = tangent;
-		int i1 = i + 1 < n ? i + 1 : n;
-		if (orientations[i].x != 0.0f || orientations[i].y != 0.0f || orientations[i].z != 0.0f) {
+		if (orientations[i] != glm::vec3()) {
 			a = orientations[i];
 		}
-		if (orientations[i1].x != 0.0f || orientations[i1].y != 0.0f || orientations[i1].z != 0.0f) {
-			b = orientations[i1];
+		if (orientations[i + 1 < n ? i + 1 : n] != glm::vec3()) {
+			b = orientations[i + 1 < n ? i + 1 : n];
 		}
+		t = (1 - cosf(t * M_PI)) * 0.5f;
 		tangent = (1 - t) * a + t * b;
 		return glm::normalize(tangent);
 	}

--- a/SplineCam/src/SplineCam/States/FollowSplineState.h
+++ b/SplineCam/src/SplineCam/States/FollowSplineState.h
@@ -20,11 +20,11 @@ public:
 			glm::vec3(-2.6f, 1.0f, 3.5f)
 		}),
 			std::vector<glm::vec3>({
-			glm::vec3(0.0f, 0.0f, 0.0f),
+			glm::vec3(),
 			glm::vec3(1.0f, 0.5f, 1.0f),
 			glm::vec3(0.0f, 0.0f, 1.0f),
 			glm::vec3(0.0f, -0.25f, 1.0f),
-			glm::vec3(0.0f, 0.0f, 0.0f)
+			glm::vec3()
 		}));
 
 		// init camera

--- a/SplineCam/src/SplineCam/States/FollowSplineState.h
+++ b/SplineCam/src/SplineCam/States/FollowSplineState.h
@@ -18,6 +18,13 @@ public:
 			glm::vec3(-11.0f, 1.0f, -2.0f),
 			glm::vec3(-11.0f, 1.0f, 3.5f),
 			glm::vec3(-2.6f, 1.0f, 3.5f)
+		}),
+			std::vector<glm::vec3>({
+			glm::vec3(0.0f, 0.0f, 0.0f),
+			glm::vec3(1.0f, 0.5f, 1.0f),
+			glm::vec3(0.0f, 0.0f, 1.0f),
+			glm::vec3(0.0f, -0.25f, 1.0f),
+			glm::vec3(0.0f, 0.0f, 0.0f)
 		}));
 
 		// init camera

--- a/SplineCam/src/SplineCam/States/FollowSplineState.h
+++ b/SplineCam/src/SplineCam/States/FollowSplineState.h
@@ -16,20 +16,20 @@ public:
 		if (spline->ControlPoints().size() == 0)
 		{
 			// The spline is not initialized so init with some random points
-      spline.Init(std::vector<glm::vec3>({
-        glm::vec3(0.0f, 1.0f, -15.0f),
-        glm::vec3(0.0f, 1.0f, -3.0f),
-        glm::vec3(-11.0f, 1.0f, -2.0f),
-        glm::vec3(-11.0f, 1.0f, 3.5f),
-        glm::vec3(-2.6f, 1.0f, 3.5f)
-      }),
-        std::vector<glm::vec3>({
-        glm::vec3(),
-        glm::vec3(1.0f, 0.5f, 1.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f),
-        glm::vec3(0.0f, -0.25f, 1.0f),
-        glm::vec3()
-      }));
+			spline->Init(std::vector<glm::vec3>({
+				glm::vec3(0.0f, 1.0f, -15.0f),
+				glm::vec3(0.0f, 1.0f, -3.0f),
+				glm::vec3(-11.0f, 1.0f, -2.0f),
+				glm::vec3(-11.0f, 1.0f, 3.5f),
+				glm::vec3(-2.6f, 1.0f, 3.5f)
+			}),
+			std::vector<glm::vec3>({
+				glm::vec3(),
+				glm::vec3(1.0f, 0.5f, 1.0f),
+				glm::vec3(0.0f, 0.0f, 1.0f),
+				glm::vec3(0.0f, -0.25f, 1.0f),
+				glm::vec3()
+			}));
 		}
 
 		camera.Init(spline, 45.0f, 1024.0f / 768.0f, 0.1f, 1000000.0f);

--- a/SplineCam/src/SplineCam/States/SplineEditorState.h
+++ b/SplineCam/src/SplineCam/States/SplineEditorState.h
@@ -20,20 +20,20 @@ public:
 		if (spline->ControlPoints().size() == 0)
 		{
 			// The spline is not initialized so init with some random points
-      spline.Init(std::vector<glm::vec3>({
-        glm::vec3(0.0f, 1.0f, -15.0f),
-        glm::vec3(0.0f, 1.0f, -3.0f),
-        glm::vec3(-11.0f, 1.0f, -2.0f),
-        glm::vec3(-11.0f, 1.0f, 3.5f),
-        glm::vec3(-2.6f, 1.0f, 3.5f)
-      }),
-        std::vector<glm::vec3>({
-        glm::vec3(),
-        glm::vec3(1.0f, 0.5f, 1.0f),
-        glm::vec3(0.0f, 0.0f, 1.0f),
-        glm::vec3(0.0f, -0.25f, 1.0f),
-        glm::vec3()
-      }));
+			spline->Init(std::vector<glm::vec3>({
+				glm::vec3(0.0f, 1.0f, -15.0f),
+				glm::vec3(0.0f, 1.0f, -3.0f),
+				glm::vec3(-11.0f, 1.0f, -2.0f),
+				glm::vec3(-11.0f, 1.0f, 3.5f),
+				glm::vec3(-2.6f, 1.0f, 3.5f)
+			}),
+				std::vector<glm::vec3>({
+				glm::vec3(),
+				glm::vec3(1.0f, 0.5f, 1.0f),
+				glm::vec3(0.0f, 0.0f, 1.0f),
+				glm::vec3(0.0f, -0.25f, 1.0f),
+				glm::vec3()
+			}));
 		}
 	}
 
@@ -64,7 +64,7 @@ public:
 
 		case GLFW_KEY_BACKSPACE:
 			if (Input::isKeyPressed(GLFW_KEY_LEFT_SHIFT))
-				spline.DeleteCustomOrientation();
+				spline->DeleteCustomOrientation();
 			break;
 
 		case GLFW_KEY_F2:
@@ -106,7 +106,7 @@ protected:
 			int ay = Input::isKeyPressed(GLFW_KEY_LEFT) - Input::isKeyPressed(GLFW_KEY_RIGHT);
 			if (ax != 0 || ay != 0)
 			{
-				spline.RotateControlPoint(ax * speed, ay * speed);
+				spline->RotateControlPoint(ax * speed, ay * speed);
 			}
 		}
 	}

--- a/SplineCam/src/SplineCam/States/SplineEditorState.h
+++ b/SplineCam/src/SplineCam/States/SplineEditorState.h
@@ -23,11 +23,11 @@ public:
 			glm::vec3(-2.6f, 1.0f, 3.5f)
 		}),
 			std::vector<glm::vec3>({
-			glm::vec3(0.0f, 0.0f, 0.0f),
-			glm::vec3(0.0f, 0.0f, 0.0f),
-			glm::vec3(0.0f, 1.0f, 0.0f),
-			glm::vec3(0.0f, 0.0f, 0.0f),
-			glm::vec3(0.0f, 0.0f, 0.0f)
+			glm::vec3(),
+			glm::vec3(1.0f, 0.5f, 1.0f),
+			glm::vec3(0.0f, 0.0f, 1.0f),
+			glm::vec3(0.0f, -0.25f, 1.0f),
+			glm::vec3()
 		}));
 	}
 

--- a/SplineCam/src/SplineCam/States/SplineEditorState.h
+++ b/SplineCam/src/SplineCam/States/SplineEditorState.h
@@ -21,6 +21,13 @@ public:
 			glm::vec3(-11.0f, 1.0f, -2.0f),
 			glm::vec3(-11.0f, 1.0f, 3.5f),
 			glm::vec3(-2.6f, 1.0f, 3.5f)
+		}),
+			std::vector<glm::vec3>({
+			glm::vec3(0.0f, 0.0f, 0.0f),
+			glm::vec3(0.0f, 0.0f, 0.0f),
+			glm::vec3(0.0f, 1.0f, 0.0f),
+			glm::vec3(0.0f, 0.0f, 0.0f),
+			glm::vec3(0.0f, 0.0f, 0.0f)
 		}));
 	}
 

--- a/SplineCam/src/SplineCam/States/SplineEditorState.h
+++ b/SplineCam/src/SplineCam/States/SplineEditorState.h
@@ -56,6 +56,11 @@ public:
 				spline.CreateControlPoint();
 			break;
 
+		case GLFW_KEY_BACKSPACE:
+			if (Input::isKeyPressed(GLFW_KEY_LEFT_SHIFT))
+				spline.DeleteCustomOrientation();
+			break;
+
 		case GLFW_KEY_F2:
 			spline.ToggleDebugPoints();
 			break;
@@ -89,6 +94,13 @@ protected:
 			if (x != 0 || y != 0 || z != 0) 
 			{
 				spline.TranslateControlPoint(glm::vec3(x, y, z) * speed);
+			}
+
+			int ax = Input::isKeyPressed(GLFW_KEY_UP) - Input::isKeyPressed(GLFW_KEY_DOWN);
+			int ay = Input::isKeyPressed(GLFW_KEY_LEFT) - Input::isKeyPressed(GLFW_KEY_RIGHT);
+			if (ax != 0 || ay != 0)
+			{
+				spline.RotateControlPoint(ax * speed, ay * speed);
 			}
 		}
 	}


### PR DESCRIPTION
Adds the possibility for a control point to also indicate an orientation.
Camera's orientation going through the spline will be interpolated taking this custom orientation into account.
If a control point doesn't indicate a custom orientation, the spline tangent will be used (as before).